### PR TITLE
🐞 Fix bug in Cloud Platform's prompt

### DIFF
--- a/features/src/cloud-platform/CHANGELOG.md
+++ b/features/src/cloud-platform/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed rogue `&&` from features/src/cloud-platform/src/home/vscode/.devcontainer/promptrc.d/cloud-platform.sh
 
+- Updates logic in Cloud Platform prompt
+
 ## [0.0.2] - 2024-01-31
 
 ### Added

--- a/features/src/cloud-platform/CHANGELOG.md
+++ b/features/src/cloud-platform/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2024-02-01
+
+### Changed
+
+- Removed rogue `&&` from features/src/cloud-platform/src/home/vscode/.devcontainer/promptrc.d/cloud-platform.sh
+
 ## [0.0.2] - 2024-01-31
 
 ### Added

--- a/features/src/cloud-platform/devcontainer-feature.json
+++ b/features/src/cloud-platform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "cloud-platform",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "Cloud Platform",
   "description": "Installs the Cloud Platform CLI",
   "options": {

--- a/features/src/cloud-platform/src/home/vscode/.devcontainer/promptrc.d/cloud-platform.sh
+++ b/features/src/cloud-platform/src/home/vscode/.devcontainer/promptrc.d/cloud-platform.sh
@@ -6,7 +6,7 @@ PROMPT+='`\
   kubectlCurrentNamespace=$(kubectl config view --minify --output "jsonpath={..namespace}"); \
   kubectlClientId=$(kubectl config view --output json | jq -r ".users[0].user[\"auth-provider\"].config[\"client-id\"]"); \
   kubectlServerVersion=$(kubectl version --output json 2>/dev/null | jq -r .serverVersion.gitVersion | sed "s/v//"); \
-  && if [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ "${kubectlClientId}" == "REPLACE_WITH_CLIENT_ID" ]]; then \
+  if [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ "${kubectlClientId}" == "REPLACE_WITH_CLIENT_ID" ]]; then \
     echo -n "[ cluster: %{$fg[yellow]%}${kubectlCurrentContext} (requires authentication)%{$reset_color%} ] "; \
   elif [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ ! -z "${kubectlServerVersion}" ]]; then \
     echo -n "[ cluster: %{$fg[green]%}${kubectlCurrentContext} (authenticated)%{$reset_color%} ] "; \

--- a/features/src/cloud-platform/src/home/vscode/.devcontainer/promptrc.d/cloud-platform.sh
+++ b/features/src/cloud-platform/src/home/vscode/.devcontainer/promptrc.d/cloud-platform.sh
@@ -5,12 +5,12 @@ PROMPT+='`\
   kubectlCurrentContext=$(kubectl config current-context 2>/dev/null); \
   kubectlCurrentNamespace=$(kubectl config view --minify --output "jsonpath={..namespace}"); \
   kubectlClientId=$(kubectl config view --output json | jq -r ".users[0].user[\"auth-provider\"].config[\"client-id\"]"); \
-  kubectlServerVersion=$(kubectl version --output json 2>/dev/null | jq -r .serverVersion.gitVersion | sed "s/v//"); \
+  kubectlServerVersion=$(kubectl version --output json 2>/dev/null | jq -r .serverVersion.gitVersion); \
   if [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ "${kubectlClientId}" == "REPLACE_WITH_CLIENT_ID" ]]; then \
     echo -n "[ cluster: %{$fg[yellow]%}${kubectlCurrentContext} (requires authentication)%{$reset_color%} ] "; \
-  elif [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ ! -z "${kubectlServerVersion}" ]]; then \
+  elif [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ "${kubectlClientId}" != "REPLACE_WITH_CLIENT_ID" ]] && [[ "${kubectlServerVersion}" != "null" ]]; then \
     echo -n "[ cluster: %{$fg[green]%}${kubectlCurrentContext} (authenticated)%{$reset_color%} ] "; \
-  else
+  elif [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ "${kubectlClientId}" != "REPLACE_WITH_CLIENT_ID" ]] && [[ "${kubectlServerVersion}" == "null" ]]; then
     echo -n "[ cluster: %{$fg[red]%}${kubectlCurrentContext} (issue with authentication)%{$reset_color%} ] "; \
   fi \
   && if [[ "${kubectlCurrentContext}" == "cloud-platform-live" ]] && [[ ! -z "${kubectlCurrentNamespace}" ]] && [[ "${kubectlCurrentNamespace}" == *"-prod"* ]]; then \


### PR DESCRIPTION
This pull request:

- Removes a rouge `&&` from `features/src/cloud-platform/src/home/vscode/.devcontainer/promptrc.d/cloud-platform.sh` which caused

  ```
  zsh: parse error near `&&'                                                                                                                                                                                                                                                                                         
  zsh: parse error in command substitution
  ```
- Updates logic in prompt

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>