### PR TITLE
:wrench: Add dotfile functionality

### DIFF
--- a/images/base/CHANGELOG.md
+++ b/images/base/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.0.5] - 2024-02-13
+
+### Added
+
+- Automatically source `.sh` files in `/home/vscode/.dotfiles` 
+
 ## [0.0.4] - 2024-02-08
 
 ### Changed

--- a/images/base/CHANGELOG.md
+++ b/images/base/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Automatically source `.sh` files in `/home/vscode/.dotfiles` 
+- Automatically source `.sh` files in `/home/vscode/.dotfiles`
 
 ## [0.0.4] - 2024-02-08
 

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update --yes \
     && chsh --shell "$(which zsh)" vscode \
     && install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer \
     && install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer/featurerc.d \
-    && install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer/promptrc.d
+    && install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer/promptrc.d \
+    && install --directory --owner=vscode --group=vscode /home/vscode/.dotfiles
 
 RUN cat <<EOF >> /home/vscode/.zshrc
 
@@ -36,6 +37,12 @@ if [ "\$(ls -A /home/vscode/.devcontainer/featurerc.d)" ]; then
   done
 fi
 
+# dotfiles
+if [ -z "\${CODESPACES}" ]; then
+  for file in /home/vscode/.dotfiles/*.sh; do
+    source "\${file}"
+  done
+fi
 EOF
 
 ONBUILD RUN apt-get update --yes \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -37,8 +37,8 @@ if [ "\$(ls -A /home/vscode/.devcontainer/featurerc.d)" ]; then
   done
 fi
 
-# dotfiles
-if [ -z "\${CODESPACES}" ]; then
+# dotfiles (running locally)
+if [ -z "\${CODESPACES}" ] && [ "\$(ls -A /home/vscode/.dotfiles)" ]; then
   for file in /home/vscode/.dotfiles/*.sh; do
     source "\${file}"
   done

--- a/images/base/config.json
+++ b/images/base/config.json
@@ -1,4 +1,4 @@
 {
   "name": "base",
-  "version": "0.0.4"
+  "version": "0.0.5"
 }


### PR DESCRIPTION
This PR will allow us to utilise dotfiles in repositories which call this Dev Container. 

In short, we need to tell the container to source the contents of `/home/vscode/.dotfiles`. 