### PR TITLE
🎨 Update `base` Dockerfile

### DIFF
--- a/images/base/CHANGELOG.md
+++ b/images/base/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2024-04-16
+
+### Changed
+
+- Updated Dockerfile syntax
+
+- Switch to using snippets instead of inline HereDoc
+
 ## [0.0.6] - 2024-04-08
 
 ### Changed

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -7,47 +7,56 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Dev Container Community" \
       org.opencontainers.image.title="Base Image" \
-      org.opencontainers.image.description="Extended version of Microsoft's image" \
+      org.opencontainers.image.description="Extension of Microsoft's image" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/.devcontainer/images/base"
+
+SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 
 COPY --chown=nobody:nobody --chmod=0755 src/usr/local/bin/devcontainer-utils /usr/local/bin/devcontainer-utils
 COPY --chown=nobody:nobody --chmod=0444 src/usr/local/etc/vscode-dev-containers/first-run-notice.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+COPY --chown=vscode:vscode --chmod=0755 src/home/vscode/.zshrc.snippet /home/vscode/.zshrc.snippet
 COPY --chown=vscode:vscode --chmod=0755 src/home/vscode/.oh-my-zsh/custom/themes/devcontainers.zsh-theme /home/vscode/.oh-my-zsh/custom/themes/devcontainers.zsh-theme
 
-RUN apt-get update --yes \
-    && apt-get upgrade --yes \
-    && apt-get install --yes --no-install-recommends \
-         python3-pip \
-    && apt-get clean --yes \
-    && rm --force --recursive /var/lib/apt/lists/* \
-    && python3 -m pip install --no-cache-dir --upgrade \
-         pip \
-    && chsh --shell "$(which zsh)" vscode \
-    && install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer \
-    && install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer/featurerc.d \
-    && install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer/promptrc.d \
-    && install --directory --owner=vscode --group=vscode /home/vscode/.dotfiles
+RUN <<EOF
+apt-get update --yes
 
-RUN cat <<EOF >> /home/vscode/.zshrc
+apt-get upgrade --yes
 
-# dev container feature completion scripts
-if [ "\$(ls -A /home/vscode/.devcontainer/featurerc.d)" ]; then
-  for file in /home/vscode/.devcontainer/featurerc.d/*.sh; do
-    source "\${file}"
-  done
-fi
+apt-get install --yes --no-install-recommends \
+  python3-pip
 
-# dotfiles (running locally)
-if [ -z "\${CODESPACES}" ] && [ "\$(ls -A /home/vscode/.dotfiles)" ]; then
-  for file in /home/vscode/.dotfiles/*.sh; do
-    source "\${file}"
-  done
-fi
+apt-get clean --yes
+
+rm --force --recursive /var/lib/apt/lists/*
+
+python3 -m pip install --no-cache-dir --upgrade \
+  pip
+
+chsh --shell "$(which zsh)" vscode
+
+cat /home/vscode/.zshrc.snippet >> /home/vscode/.zshrc
+
+rm --force /home/vscode/.zshrc.snippet
+
+install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer
+
+install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer/featurerc.d
+
+install --directory --owner=vscode --group=vscode /home/vscode/.devcontainer/promptrc.d
+
+install --directory --owner=vscode --group=vscode /home/vscode/.dotfiles
 EOF
 
-ONBUILD RUN apt-get update --yes \
-            && apt-get upgrade --yes \
-            && apt-get clean --yes \
-            && rm --force --recursive /var/lib/apt/lists/* \
-            && python3 -m pip install --no-cache-dir --upgrade \
-                 pip
+
+ONBUILD RUN <<EOF
+apt-get update --yes
+
+apt-get upgrade --yes
+
+apt-get clean --yes
+
+rm --force --recursive /var/lib/apt/lists/*
+
+python3 -m pip install --no-cache-dir --upgrade \
+  pip
+EOF

--- a/images/base/config.json
+++ b/images/base/config.json
@@ -1,4 +1,4 @@
 {
   "name": "base",
-  "version": "0.0.6"
+  "version": "1.0.0"
 }

--- a/images/base/src/home/vscode/.zshrc.snippet
+++ b/images/base/src/home/vscode/.zshrc.snippet
@@ -1,0 +1,13 @@
+# dev container feature completion scripts
+if [ "$(ls -A /home/vscode/.devcontainer/featurerc.d)" ]; then
+  for file in /home/vscode/.devcontainer/featurerc.d/*.sh; do
+    source "${file}"
+  done
+fi
+
+# dotfiles (running locally)
+if [ -z "${CODESPACES}" ] && [ "$(ls -A /home/vscode/.dotfiles)" ]; then
+  for file in /home/vscode/.dotfiles/*.sh; do
+    source "${file}"
+  done
+fi


### PR DESCRIPTION
This pull request:

- Updates Dockerfile to use HereDoc syntax
- Uses snippets instead of inline HereDoc
- Bumps `base` to `1.0.0`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 