### PR TITLE
📌 Update base image to Ubuntu 24.04

### DIFF
--- a/images/base/CHANGELOG.md
+++ b/images/base/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2024-05-13
+
+### Changed
+
+- Updated image to Ubuntu 24.04
+- Updated references to `1000`, `vscode` user is now `1001`
+
 ## [1.0.0] - 2024-04-16
 
 ### Changed

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -2,7 +2,7 @@
 #checkov:skip=CKV_DOCKER_3: USER not required - A non-root user is created, and used by VS Code's Remote Containers extension
 # hadolint global ignore=DL3008,DL3013
 
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Dev Container Community" \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -22,15 +22,12 @@ apt-get update --yes
 
 apt-get upgrade --yes
 
-apt-get install --yes --no-install-recommends \
+apt-get install --yes \
   python3-pip
 
 apt-get clean --yes
 
 rm --force --recursive /var/lib/apt/lists/*
-
-python3 -m pip install --no-cache-dir --upgrade \
-  pip
 
 chsh --shell "$(which zsh)" vscode
 
@@ -56,7 +53,4 @@ apt-get upgrade --yes
 apt-get clean --yes
 
 rm --force --recursive /var/lib/apt/lists/*
-
-python3 -m pip install --no-cache-dir --upgrade \
-  pip
 EOF

--- a/images/base/config.json
+++ b/images/base/config.json
@@ -1,4 +1,4 @@
 {
   "name": "base",
-  "version": "1.0.0"
+  "version": "2.0.0"
 }

--- a/images/base/src/usr/local/bin/devcontainer-utils
+++ b/images/base/src/usr/local/bin/devcontainer-utils
@@ -77,5 +77,5 @@ apt_install() {
 pip_install() {
   local packages="${1}"
 
-  python3 -m pip install --no-cache-dir --upgrade "${packages}"
+  python3 -m pip install --no-cache-dir --upgrade --break-system-packages "${packages}"
 }

--- a/images/base/test/container-structure-test.yml
+++ b/images/base/test/container-structure-test.yml
@@ -5,17 +5,17 @@ commandTests:
   - name: "vscode user"
     command: "id"
     args: ["--user", "vscode"]
-    expectedOutput: ["1000"]
+    expectedOutput: ["1001"]
 
   - name: "vscode group"
     command: "id"
     args: ["--group", "vscode"]
-    expectedOutput: ["1000"]
+    expectedOutput: ["1001"]
 
   - name: "vscode user getent"
     command: "getent"
     args: ["passwd", "vscode" ]
-    expectedOutput: ["vscode:x:1000:1000::/home/vscode:/usr/bin/zsh"]
+    expectedOutput: ["vscode:x:1001:1001::/home/vscode:/usr/bin/zsh"]
 
   - name: "pip"
     command: "pip"
@@ -41,22 +41,22 @@ fileExistenceTests:
     path: "/home/vscode/.oh-my-zsh/custom/themes/devcontainers.zsh-theme"
     shouldExist: true
     permissions: "-rwxr-xr-x" # 0755
-    uid: 1000
-    gid: 1000
+    uid: 1001
+    gid: 1001
 
   - name: "featurerc.d"
     path: "/home/vscode/.devcontainer/featurerc.d"
     shouldExist: true
     permissions: "drwxr-xr-x" # 0755
-    uid: 1000
-    gid: 1000
+    uid: 1001
+    gid: 1001
 
   - name: "promptrc.d"
     path: "/home/vscode/.devcontainer/promptrc.d"
     shouldExist: true
     permissions: "drwxr-xr-x" # 0755
-    uid: 1000
-    gid: 1000
+    uid: 1001
+    gid: 1001
 
 fileContentTests:
   - name: "zshrc featurerc.d"


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/.devcontainer/issues/71
- Bumps the base image to Ubuntu 24.04
  - https://github.com/devcontainers/images/releases/tag/v0.3.36
- Updates references of UID `1000` to `1001`, as Ubuntu 24.04 ships with the `ubuntu` user as `1001`
  - https://github.com/devcontainers/images/pull/1036
- Adds `--break-system-packages` to `pip_install`, this is related to the `externally-managed-environment` error below, I don't think virtual environments are needed to system wide installations like this 🤷 

Tested features:

```bash
bash scripts/features/test.sh ${feature}
```

- [x] `aws`
- [x] `cloud-platform`
  - ~`kubernetes` dependency is failing~
- [x] `container-structure-test`
  - `docker-in-docker` dependency is failing
  - Have reached out on github-partners' devcontainers-community Slack
    - https://github.com/devcontainers/features/issues/967
      - https://github.com/devcontainers/features/pull/969
      - https://github.com/devcontainers/features/pull/971
- [x] `kubernetes`
- [x] `static-analysis`
- [x] `terraform`

Python management of `pip` in base image removed from `ONBUILD` due to:

```bash
$ python3 -m pip install --no-cache-dir --upgrade pip
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 