### PR TITLE
:wrench: Add `postStartCommand` to resolve dubious ownership

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
     "ghcr.io/devcontainers/features/node:1": {}
   },
   "postCreateCommand": "npm install --global @devcontainers/cli",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
Tested in the `.devcontainer` Dev Container by building with and without this command. Noted from [this](https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/) blog.

Resolves [this](https://github.com/ministryofjustice/.devcontainer/issues/120) issue.