### PR TITLE
📌 Update and pin base to 1.2.0

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Scan Image
         id: scan_image
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # 0.24.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           scan-type: image
           image-ref: ghcr.io/ministryofjustice/devcontainer-${{ matrix.image }}:${{ github.sha }}

--- a/images/base/CHANGELOG.md
+++ b/images/base/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2024-05-13
+
+### Changes
+
+- Pinned to [1.2.0](https://github.com/devcontainers/images/blob/main/src/base-ubuntu/history/1.2.0.md)
+
+- Reverted user change, now back at `1000:1000`
+
 ## [2.0.0] - 2024-05-13
 
 ### Changed

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -2,7 +2,7 @@
 #checkov:skip=CKV_DOCKER_3: USER not required - A non-root user is created, and used by VS Code's Remote Containers extension
 # hadolint global ignore=DL3008,DL3013
 
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/base:1.2.0-ubuntu-24.04
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Dev Container Community" \

--- a/images/base/config.json
+++ b/images/base/config.json
@@ -1,4 +1,4 @@
 {
   "name": "base",
-  "version": "2.0.0"
+  "version": "3.0.0"
 }

--- a/images/base/test/container-structure-test.yml
+++ b/images/base/test/container-structure-test.yml
@@ -41,22 +41,22 @@ fileExistenceTests:
     path: "/home/vscode/.oh-my-zsh/custom/themes/devcontainers.zsh-theme"
     shouldExist: true
     permissions: "-rwxr-xr-x" # 0755
-    uid: 1001
-    gid: 1001
+    uid: 1000
+    gid: 1000
 
   - name: "featurerc.d"
     path: "/home/vscode/.devcontainer/featurerc.d"
     shouldExist: true
     permissions: "drwxr-xr-x" # 0755
-    uid: 1001
-    gid: 1001
+    uid: 1000
+    gid: 1000
 
   - name: "promptrc.d"
     path: "/home/vscode/.devcontainer/promptrc.d"
     shouldExist: true
     permissions: "drwxr-xr-x" # 0755
-    uid: 1001
-    gid: 1001
+    uid: 1000
+    gid: 1000
 
 fileContentTests:
   - name: "zshrc featurerc.d"

--- a/images/base/test/container-structure-test.yml
+++ b/images/base/test/container-structure-test.yml
@@ -5,17 +5,17 @@ commandTests:
   - name: "vscode user"
     command: "id"
     args: ["--user", "vscode"]
-    expectedOutput: ["1001"]
+    expectedOutput: ["1000"]
 
   - name: "vscode group"
     command: "id"
     args: ["--group", "vscode"]
-    expectedOutput: ["1001"]
+    expectedOutput: ["1000"]
 
   - name: "vscode user getent"
     command: "getent"
     args: ["passwd", "vscode"]
-    expectedOutput: ["vscode:x:1001:1001::/home/vscode:/usr/bin/zsh"]
+    expectedOutput: ["vscode:x:1000:1000::/home/vscode:/usr/bin/zsh"]
 
   - name: "pip"
     command: "pip"


### PR DESCRIPTION
This pull request:

- Updates base image to [1.2.0](https://github.com/devcontainers/images/blob/main/src/base-ubuntu/history/1.2.0.md)

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>  