### PR TITLE
☸️ Set `installKubernetesCliPrompt` to `false`

### DIFF
--- a/features/src/cloud-platform/CHANGELOG.md
+++ b/features/src/cloud-platform/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2024-10-17
+
+## Changed
+
+- set `installKubernetesCliPrompt` to `false` for `ghcr.io/ministryofjustice/devcontainer-feature/kubernetes`
+
+- Promote to 1.0.0
+
 ## [0.0.5] - 2024-10-07
 
 ## Changed

--- a/features/src/cloud-platform/devcontainer-feature.json
+++ b/features/src/cloud-platform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "cloud-platform",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "name": "Cloud Platform",
   "description": "Installs the Cloud Platform CLI",
   "options": {
@@ -22,7 +22,8 @@
   },
   "dependsOn": {
     "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
-      "kubernetesCliVersion": "v1.29.9"
+      "kubernetesCliVersion": "v1.29.9",
+      "installKubernetesCliPrompt": false
     }
   }
 }


### PR DESCRIPTION
This pull request:

- Resolves https://github.com/ministryofjustice/.devcontainer/issues/147 by setting `installKubernetesCliPrompt` to `false`, as a result not installing `~/.devcontainer/promptrc.d/kubernetes-cli.sh`

Once authenticated, it looks like

```bash
vscode ➜ /workspaces/cloud-platform-environments (main) [ cluster: cloud-platform-live (authenticated) ] [ namespace: data-platform-production ] $
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 