### PR TITLE
📌 Update base image version

### DIFF
--- a/images/base/CHANGELOG.md
+++ b/images/base/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2025-01-27
+
+### Changes
+
+- Updated to [1.2.3](https://github.com/devcontainers/images/blob/main/src/base-ubuntu/history/1.2.3.md)
+
 ## [3.0.0] - 2024-05-13
 
 ### Changes

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -2,7 +2,7 @@
 #checkov:skip=CKV_DOCKER_3: USER not required - A non-root user is created, and used by VS Code's Remote Containers extension
 # hadolint global ignore=DL3008,DL3013
 
-FROM mcr.microsoft.com/devcontainers/base:1.2.0-ubuntu-24.04
+FROM mcr.microsoft.com/devcontainers/base:1.2.3-ubuntu-24.04
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Dev Container Community" \

--- a/images/base/config.json
+++ b/images/base/config.json
@@ -1,4 +1,4 @@
 {
   "name": "base",
-  "version": "3.0.0"
+  "version": "3.1.0"
 }


### PR DESCRIPTION
This pull request:

- Updates the base image to [`1.2.3`](https://github.com/devcontainers/images/blob/main/src/base-ubuntu/history/1.2.3.md)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 