### PR TITLE
Remove aquasecurity/trivy-action from .github/workflows/images.yml

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -176,18 +176,7 @@ jobs:
 
       - name: Scan Image
         id: scan_image
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
-        with:
-          scan-type: image
-          image-ref: ghcr.io/ministryofjustice/devcontainer-${{ matrix.image }}:${{ github.sha }}
-          exit-code: 1
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          hide-progress: true
-
+        run: exit 0 # trivy-action step removed
   publish:
     needs: [detect-changes]
     if: ${{ needs.detect-changes.outputs.images != '[]' && github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Why

`aquasecurity/trivy-action` has been compromised for the second time. All tags before `0.35.0` were re-pointed to a malicious commit that **dumps process memory to steal credentials** from CI runners.

- **Issue:** https://github.com/aquasecurity/trivy-action/issues/541
- **Exposure window (UTC):** 2026-03-19 ~17:43 – 2026-03-20 ~05:40
- **Malicious commit:** `aquasecurity/setup-trivy@8afa9b9`
- **Details:** https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release

As [recommended by the maintainers](https://github.com/aquasecurity/trivy-action/issues/541#issuecomment-2737987938):

> "As hard as it may be: do not use Trivy anymore for now."

Any repository that ran a workflow using this action during the exposure window may have had secrets exfiltrated. **Rotate any secrets that were available to workflows using this action.**

## What this PR does

Removes the `aquasecurity/trivy-action` step(s) from this workflow. The `uses:` directive and its `with:` block have been replaced with a `run:` step that creates an empty but valid SARIF file (where applicable), so downstream steps (e.g. `upload-sarif`) continue to pass.

> **Note:** Repo owners should review whether the entire workflow/job can now be removed, or whether an alternative scanning solution should be adopted.

Raised automatically for review.
