### PR TITLE
fix: follow GitHub API redirects in get_github_latest_tag and update Velero repo

### DIFF
--- a/features/src/kubernetes/CHANGELOG.md
+++ b/features/src/kubernetes/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-05-13
+
+- Update Velero repository
+
 ## [1.1.1] - 2026-04-15
 
 - Minor internal changes and improvements.

--- a/features/src/kubernetes/devcontainer-feature.json
+++ b/features/src/kubernetes/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "kubernetes",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "name": "Kubernetes",
   "description": "Installs the Kubernetes CLI, Helm CLI and Helm Chart Testing CLI",
   "options": {

--- a/features/src/kubernetes/install-velero-cli.sh
+++ b/features/src/kubernetes/install-velero-cli.sh
@@ -8,7 +8,7 @@ source /usr/local/bin/devcontainer-utils
 
 get_system_architecture
 
-GITHUB_REPOSITORY="vmware-tanzu/velero"
+GITHUB_REPOSITORY="velero-io/velero"
 VERSION=${VELEROCLIVERSION:-"latest"}
 
 if [[ "${VERSION}" == "latest" ]]; then

--- a/images/base/CHANGELOG.md
+++ b/images/base/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-05-07
+
+### Changes
+
+- fix: follow GitHub API redirects in get_github_latest_tag
+
 ## [4.1.0] - 2026-04-22
 
 ### Changes

--- a/images/base/config.json
+++ b/images/base/config.json
@@ -1,4 +1,4 @@
 {
   "name": "base",
-  "version": "4.1.0"
+  "version": "4.2.0"
 }

--- a/images/base/src/usr/local/bin/devcontainer-utils
+++ b/images/base/src/usr/local/bin/devcontainer-utils
@@ -52,7 +52,7 @@ get_system_architecture() {
 get_github_latest_tag() {
   local repository="${1}"
 
-  repositoryLatestTag="$(curl --silent https://api.github.com/repos/"${repository}"/releases/latest | jq -r '.tag_name')"
+  repositoryLatestTag="$(curl --silent --location https://api.github.com/repos/"${repository}"/releases/latest | jq -r '.tag_name')"
   export repositoryLatestTag
 
   repositoryLatestTagStripV=${repositoryLatestTag//v/}


### PR DESCRIPTION
Added `--location `to the curl call in `get_github_latest_tag` so that HTTP redirects are followed automatically. This fixes the Velero CLI install and also benefits any other tool that uses this utility function against a redirected GitHub API endpoint.

Also updates the repository that Velero is installed from, and bumps the kubernetes feature and base versions

This work is to resolve the following [issue ](https://github.com/ministryofjustice/.devcontainer/issues/260)

