### PR TITLE
bug: minor fix to aws-sso installation

### DIFF
--- a/features/src/aws/CHANGELOG.md
+++ b/features/src/aws/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.1.2] - 2026-05-21
 
 - Fixed `install-aws-sso-cli.sh` referencing incorrect variable `AWSVAULTVERSION` instead of `AWSSSOCLIVERSION` for version selection

--- a/features/src/aws/CHANGELOG.md
+++ b/features/src/aws/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.2] - 2026-05-21
+
+- Fixed `install-aws-sso-cli.sh` referencing incorrect variable `AWSVAULTVERSION` instead of `AWSSSOCLIVERSION` for version selection
 
 ## [1.1.1] - 2026-04-15
 

--- a/features/src/aws/devcontainer-feature.json
+++ b/features/src/aws/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "aws",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "name": "AWS",
   "documentationURL": "https://github.com/ministryofjustice/.devcontainer/tree/main/features/src/aws",
   "description": "Installs the AWS CLI and AWS SSO CLI",

--- a/features/src/aws/install-aws-sso-cli.sh
+++ b/features/src/aws/install-aws-sso-cli.sh
@@ -9,7 +9,7 @@ source /usr/local/bin/devcontainer-utils
 get_system_architecture
 
 GITHUB_REPOSITORY="synfinatic/aws-sso-cli"
-VERSION="${AWSVAULTVERSION:-"latest"}"
+VERSION="${AWSSSOCLIVERSION:-"latest"}"
 INSTALL_PROMPT="${INSTALLAWSSSOCLIPROMPT:-"true"}"
 
 if [[ "${VERSION}" == "latest" ]]; then


### PR DESCRIPTION
The `install-aws-sso-cli.sh` script was referencing `AWSVAULTVERSION` instead of `AWSSSOCLIVERSION` for version selection. This meant the `awsSsoCliVersion` option defined in `devcontainer-feature.json` was silently ignored, and the script always fell through to `"latest"`.

### Changes

- Updated `install-aws-sso-cli.sh` to reference the correct environment variable `AWSSSOCLIVERSION`
- Bumped feature version to 1.1.2